### PR TITLE
TourData API calls, tours read from backend, start tour details page

### DIFF
--- a/src/api/locationData.js
+++ b/src/api/locationData.js
@@ -76,7 +76,7 @@ const updateLocation = (payload) =>
 const getSingleLocation = (LocationId) =>
   new Promise((resolve, reject) => {
     fetch(
-      `${endpoint}/${LocationId}.json`,
+      `${endpoint}/${LocationId}`,
       { cache: 'no-store' },
       {
         method: 'GET',

--- a/src/api/tourData.js
+++ b/src/api/tourData.js
@@ -1,13 +1,12 @@
-import { clientCredentials } from '@/utils/client';
 // API CALLS FOR TOURS
 
-const endpoint = clientCredentials.databaseURL;
-// const endpoint = 'http://localhost:8000';
+// const endpoint = clientCredentials.databaseURL;
+const endpoint = 'http://localhost:8000/tours';
 
 // GET ALL TOURS FOR A SPECIFIC USER
 const getTours = (uid) =>
   new Promise((resolve, reject) => {
-    fetch(`${endpoint}/tours.json?orderBy="uid"&equalTo="${uid}"`, {
+    fetch(`${endpoint}?uid="${uid}"`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -24,10 +23,10 @@ const getTours = (uid) =>
       .catch(reject);
   });
 
-// DELETE BOOK
-const deleteTour = (firebaseKey) =>
+// DELETE TOUR
+const deleteTour = (TourId) =>
   new Promise((resolve, reject) => {
-    fetch(`${endpoint}/tours/${firebaseKey}.json`, {
+    fetch(`${endpoint}/${TourId}.json`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
@@ -39,9 +38,9 @@ const deleteTour = (firebaseKey) =>
   });
 
 // GET SINGLE TOUR
-const getSingleTour = (firebaseKey) =>
+const getSingleTour = (TourId) =>
   new Promise((resolve, reject) => {
-    fetch(`${endpoint}/tours/${firebaseKey}.json`, {
+    fetch(`${endpoint}/tours/${TourId}.json`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -55,7 +54,7 @@ const getSingleTour = (firebaseKey) =>
 // CREATE TOUR
 const createTour = (payload) =>
   new Promise((resolve, reject) => {
-    fetch(`${endpoint}/tours.json`, {
+    fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -70,7 +69,7 @@ const createTour = (payload) =>
 // UPDATE TOUR
 const updateTour = (payload) =>
   new Promise((resolve, reject) => {
-    fetch(`${endpoint}/tours/${payload.firebaseKey}.json`, {
+    fetch(`${endpoint}${payload.id}.json`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',

--- a/src/app/tour/[firebaseKey]/page.js
+++ b/src/app/tour/[firebaseKey]/page.js
@@ -1,7 +1,41 @@
+'use client';
+
 // view tour details here
 // put JSX here directly, no other component used in here
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { getSingleTour } from '@/api/tourData';
+import dayjs from 'dayjs';
+import PropTypes from 'prop-types';
 
-export default function page() {
-  return <div>Woohoo</div>;
+export default function TourDetailsPage({ params }) {
+  const [tour, setTour] = useState({});
+  const { firebaseKey } = params;
+
+  useEffect(() => {
+    getSingleTour(firebaseKey).then((data) => {
+      setTour(data);
+    });
+  }, [firebaseKey]);
+
+  const tourDateObj = dayjs(tour.date).format('YYYY-MM-DD');
+  const tourTimeObj = dayjs(tour.time).format('h:mm A');
+
+  return (
+    <div>
+      <h1>{tour.name}</h1>
+      <p>{tour.description}</p>
+      <p>Date: {tourDateObj}</p>
+      <p>Time: {tourTimeObj}</p>
+      <p>Duration: {tour.duration}</p>
+      <p>Price: {tour.price}</p>
+      <img src={tour.imageUrl} alt={tour.name} />
+      <p>Location: {tour.location}</p>
+    </div>
+  );
 }
+
+TourDetailsPage.propTypes = {
+  params: PropTypes.shape({
+    firebaseKey: PropTypes.string.isRequired,
+  }),
+};

--- a/src/app/tours/page.js
+++ b/src/app/tours/page.js
@@ -10,6 +10,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { getTours } from '@/api/tourData';
 import { useAuth } from '@/utils/context/authContext';
+import { getSingleLocation } from '@/api/locationData';
 
 export default function ToursPage() {
   const [tours, setTours] = useState([]);
@@ -17,13 +18,16 @@ export default function ToursPage() {
 
   const getAllTheTours = () => {
     getTours(user.uid).then((data) => {
-      setTours(data);
+      const toursWithLocationNames = data.map((tour) => getSingleLocation(tour.location).then((locationData) => ({ ...tour, locationName: locationData.name })));
+      Promise.all(toursWithLocationNames).then((updatedTours) => {
+        setTours(updatedTours);
+      });
     });
   };
 
   useEffect(() => {
     getAllTheTours();
-  }, [user?.uid]);
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
<!--- Describe your changes in detail -->

- Changed tourdata API calls
- Created skeleton for tour details page
- Updated tours page to read location from backend

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- Fixed issue where front end used location id instead of location name on tour card
- API calls for tours now read from backend

## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
