### PR TITLE
itin API Calls, connect itin to BE (commented out), create itin when click add to itin

### DIFF
--- a/src/api/itineraryData.js
+++ b/src/api/itineraryData.js
@@ -1,6 +1,49 @@
 // API CALLS FOR ITINERARY ITEMS
 const endpoint = 'http://localhost:8000/itineraries';
 
+// GET ALL ITINERARIES
+const getItineraries = () =>
+  new Promise((resolve, reject) => {
+    fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(Object.values(data)))
+      .catch(reject);
+  });
+
+// GET ITINERARIES BY UID
+const getItinerariesByUid = (uid) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}?uid=${uid}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(Object.values(data)))
+      .catch(reject);
+  });
+
+// GET A SINGLE ITINERARY BY ID
+const getSingleItinerary = (id) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}?id=${id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+// CREATE AN ITINERARY
 const createItinerary = (payload) =>
   new Promise((resolve, reject) => {
     fetch(endpoint, {
@@ -15,4 +58,46 @@ const createItinerary = (payload) =>
       .catch(reject);
   });
 
-export default createItinerary;
+// UPDATE AN ITINERARY
+const updateItinerary = (payload) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/${payload.id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+// DELETE AN ITINERARY
+const deleteItinerary = (id) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/${id}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+// GET COMPLETED ITINERARIES
+const getCompletedItineraries = () =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}?completed=true`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(Object.values(data)))
+      .catch(reject);
+  });
+
+export { getItineraries, getItinerariesByUid, getSingleItinerary, createItinerary, updateItinerary, deleteItinerary, getCompletedItineraries };

--- a/src/app/itinerary/page.js
+++ b/src/app/itinerary/page.js
@@ -1,28 +1,52 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 // loop thru to display each on ItineraryTourCard component
 
 'use client';
 
 import ItineraryTourCard from '@/components/ItineraryTourCard';
 import React, { useEffect, useState } from 'react';
-import userData from '@/utils/sample-data/users.json';
-import itineraryData from '@/utils/sample-data/itinerary.json';
 import { Map, Marker } from '@vis.gl/react-google-maps';
+// import { getItinerariesByUid } from '@/api/itineraryData';
+import { useAuth } from '@/utils/context/authContext';
+import { getSingleUser } from '@/api/profileData';
+import itineraryData from '@/utils/sample-data/itinerary.json';
 
 // gmaps variable to turn on and off Google Maps features
 const gmaps = true;
 
 export default function ItineraryPage() {
-  const [itinerary, setItinerary] = useState([]);
+  // get user ID using UseAuth Hook
+  const { user } = useAuth();
 
-  const getTheItinerary = () => {
+  const [itinerary, setItinerary] = useState([]);
+  const [userData, setUserData] = useState({});
+
+  const getTheSingleUser = () => {
+    getSingleUser(user.uid).then((data) => {
+      console.log('Fetched User Data:', data);
+      setUserData(data[0]);
+    });
+  };
+
+  useEffect(() => {
+    getTheSingleUser();
+  }, []);
+
+  // const getTheItineraries = () => {
+  //   getItinerariesByUid().then((data) => {
+  //     setItinerary(data);
+  //   });
+  // };
+
+  const getTheItineraries = () => {
     setItinerary(itineraryData);
   };
 
   useEffect(() => {
-    getTheItinerary();
-  }, [itinerary]);
+    getTheItineraries();
+  }, []);
 
-  console.log(itinerary);
+  console.log('itinerary: ', itinerary);
 
   return (
     <div>
@@ -30,7 +54,7 @@ export default function ItineraryPage() {
         {userData.first_name} {userData.last_name}&apos;s Itinerary
       </h1>
       {itinerary.map((item) => (
-        <ItineraryTourCard key={item.id} itineraryObj={item} onUpdate={getTheItinerary} />
+        <ItineraryTourCard key={item.id} itineraryObj={item} onUpdate={getTheItineraries} />
       ))}
       {gmaps ? (
         <div className="h-[500px] w-3/4 mx-auto m-4 border border-white rounded-lg overflow-hidden">

--- a/src/components/ItineraryTourCard.js
+++ b/src/components/ItineraryTourCard.js
@@ -19,7 +19,7 @@ export default function ItineraryTourCard({ itineraryObj }) {
 
   const handleCheckboxChange = () => {
     setCompleted(!completed);
-    // Patch the itinerary object with completed
+    // TODO:  Patch the itinerary object with completed
   };
 
   return (

--- a/src/components/TourCard.js
+++ b/src/components/TourCard.js
@@ -1,4 +1,5 @@
-import React from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect, useState } from 'react';
 import { Card, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
@@ -6,8 +7,10 @@ import { faLocationDot, faPenToSquare, faTrashCan } from '@fortawesome/free-soli
 import dayjs from 'dayjs';
 import Link from 'next/link';
 import { deleteTour } from '@/api/tourData';
-import { getSingleLocation } from '@/api/locationData';
-import createItinerary from '@/api/itineraryData';
+// import { getSingleLocation } from '@/api/locationData';
+import { createItinerary } from '@/api/itineraryData';
+import { useAuth } from '@/utils/context/authContext';
+import { getSingleUser } from '@/api/profileData';
 
 export default function TourCard({ tourObj, onUpdate }) {
   console.log(tourObj);
@@ -20,19 +23,55 @@ export default function TourCard({ tourObj, onUpdate }) {
     }
   };
 
+  // get user object so we can access the id
+
+  const { user } = useAuth();
+
+  const [userData, setUserData] = useState({});
+
+  const getTheSingleUser = () => {
+    getSingleUser(user.uid).then((data) => {
+      console.log('Fetched User Data:', data);
+      setUserData(data[0]);
+    });
+  };
+
+  useEffect(() => {
+    getTheSingleUser();
+  }, []);
+
+  // set state for sucess message in UI when adding to itinerary
+  const [successMessage, setSuccessMessage] = useState('');
+
+  // const addToItinerary = () => {
+  //   getSingleLocation(tourObj.location).then((location) => {
+  //     const { address, name } = location;
+  //     const payload = {
+  //       user_id: userData.id,
+  //       tourName: tourObj.name,
+  //       completed: false,
+  //       tourDate: formattedDate,
+  //       tourTime: formattedTime,
+  //       tourPrice: tourObj.price,
+  //       locationAddress: address,
+  //       locationName: name,
+  //       tour: tourObj.id,
+  //     };
+  //     createItinerary(payload); // You can remove this line after verifying the payload
+  //   });
+  // };
+
   const addToItinerary = () => {
-    getSingleLocation(tourObj.location).then((location) => {
-      const { address, name } = location;
-      const payload = {
-        tourName: tourObj.name,
-        completed: false,
-        tourDate: formattedDate,
-        tourTime: formattedTime,
-        tourPrice: tourObj.price,
-        locationAddress: address,
-        locationName: name,
-      };
-      createItinerary(payload); // You can remove this line after verifying the payload
+    const payload = {
+      user_id: userData.id,
+      tour: tourObj.id,
+      completed: false,
+    };
+    createItinerary(payload).then(() => {
+      setSuccessMessage('Tour added to itinerary!');
+      setTimeout(() => {
+        setSuccessMessage('');
+      }, 3000); // 3000 milliseconds before the message disappears
     });
   };
 
@@ -51,6 +90,8 @@ export default function TourCard({ tourObj, onUpdate }) {
             <Card.Text className="text-left">{formattedTime}</Card.Text>
           </div>
           <Card.Text>${tourObj.price}</Card.Text>
+          {/* message when added to itinerary via short-circuit conditional rendering (if successMessage is truthy it is rendered, otherwise it is not) */}
+          {successMessage && <p className="text-green-500 mt-2">{successMessage}</p>}
         </Card.Body>
         <Card.Footer className="text-muted">
           <div className="flex flex-row gap-4">


### PR DESCRIPTION

## Description
- Itinerary API calls read, update, and delete
- BE connection in the itinerary page but commented out since not working. For now, sample data still displays
- Δ payload for addToItinerary in tour card so request goes thru. Commented other stuff out instead of deleting it in case we need it later for some reason
- added message that displays for 3 seconds ~"added to itin" when user clicks add to itinerary on a tour card, to notify them/ give them button click feedback w/o re-routing to the itinerary. figured this was better since they may want to add multiple tours to their itinerary before viewing it