### PR TITLE
added protected route HOC and profile completion check

### DIFF
--- a/src/app/itinerary/page.js
+++ b/src/app/itinerary/page.js
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import userData from '@/utils/sample-data/users.json';
 import itineraryData from '@/utils/sample-data/itinerary.json';
 import { Map, Marker } from '@vis.gl/react-google-maps';
+import ProtectedRoute from '@/components/ProtectedRoute';
 
 // gmaps variable to turn on and off Google Maps features
 const gmaps = true;
@@ -25,25 +26,27 @@ export default function ItineraryPage() {
   console.log(itinerary);
 
   return (
-    <div>
-      <h1 className="text-center m-4">
-        {userData.first_name} {userData.last_name}&apos;s Itinerary
-      </h1>
-      {itinerary.map((item) => (
-        <ItineraryTourCard key={item.id} itineraryObj={item} onUpdate={getTheItinerary} />
-      ))}
-      {gmaps ? (
-        <div className="h-[500px] w-3/4 mx-auto m-4 border border-white rounded-lg overflow-hidden">
-          <Map defaultZoom={12} defaultCenter={{ lat: 36.16, lng: -86.77 }}>
-            {itinerary.map((item) => {
-              if (item.coord) {
-                return <Marker key={item.id} position={item.coord} title={item.location_name} />;
-              }
-              return null;
-            })}
-          </Map>
-        </div>
-      ) : null}
-    </div>
+    <ProtectedRoute>
+      <div>
+        <h1 className="text-center m-4">
+          {userData.first_name} {userData.last_name}&apos;s Itinerary
+        </h1>
+        {itinerary.map((item) => (
+          <ItineraryTourCard key={item.id} itineraryObj={item} onUpdate={getTheItinerary} />
+        ))}
+        {gmaps ? (
+          <div className="h-[500px] w-3/4 mx-auto m-4 border border-white rounded-lg overflow-hidden">
+            <Map defaultZoom={12} defaultCenter={{ lat: 36.16, lng: -86.77 }}>
+              {itinerary.map((item) => {
+                if (item.coord) {
+                  return <Marker key={item.id} position={item.coord} title={item.location_name} />;
+                }
+                return null;
+              })}
+            </Map>
+          </div>
+        ) : null}
+      </div>
+    </ProtectedRoute>
   );
 }

--- a/src/app/locations/page.js
+++ b/src/app/locations/page.js
@@ -10,6 +10,7 @@ import { Button } from 'react-bootstrap';
 import { getLocations } from '@/api/locationData';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import ProtectedRoute from '@/components/ProtectedRoute';
 
 export default function LocationsPage() {
   // Set a state for locations
@@ -32,21 +33,23 @@ export default function LocationsPage() {
   }, []);
 
   return (
-    <div className="text-center my-4">
-      <div className="text-center mt-3">
-        <Link href="/location/new" passHref>
-          <Button className="w-25">
-            <FontAwesomeIcon icon={faPlus} /> New Location
-          </Button>
-        </Link>
-      </div>
+    <ProtectedRoute>
+      <div className="text-center my-4">
+        <div className="text-center mt-3">
+          <Link href="/location/new" passHref>
+            <Button className="w-25">
+              <FontAwesomeIcon icon={faPlus} /> New Location
+            </Button>
+          </Link>
+        </div>
 
-      <div className="d-flex flex-wrap">
-        {/* map over locations here using LocationCard component */}
-        {locations.map((location) => (
-          <LocationCard key={location.id} locationObj={location} onUpdate={getAllTheLocations} />
-        ))}
+        <div className="d-flex flex-wrap">
+          {/* map over locations here using LocationCard component */}
+          {locations.map((location) => (
+            <LocationCard key={location.id} locationObj={location} onUpdate={getAllTheLocations} />
+          ))}
+        </div>
       </div>
-    </div>
+    </ProtectedRoute>
   );
 }

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,12 +1,25 @@
 'use client';
 
-import React from 'react';
-import ProfileForm from '@/components/forms/ProfileForm';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/utils/context/authContext';
+import { getSingleUser } from '@/api/profileData';
 
-export default function page() {
-  return (
-    <div>
-      <ProfileForm />
-    </div>
-  );
+export default function HomePage() {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) {
+      getSingleUser(user.uid).then((data) => {
+        if (data && data[0] && data[0].first_name && data[0].last_name && data[0].bio) {
+          router.push('/tours');
+        } else {
+          router.push('/profile/new');
+        }
+      });
+    }
+  }, [user, router]);
+
+  return null; // or a loading spinner
 }

--- a/src/app/profile/new/page.js
+++ b/src/app/profile/new/page.js
@@ -1,1 +1,12 @@
-// use the profile form component here
+'use client';
+
+import React from 'react';
+import ProfileForm from '@/components/forms/ProfileForm';
+
+export default function CreateProfilePage() {
+  return (
+    <div>
+      <ProfileForm />
+    </div>
+  );
+}

--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -1,22 +1,30 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-
 'use client';
 
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable react/function-component-definition */
 
-import { useEffect, useState, React } from 'react';
+import { useEffect, useState } from 'react';
 import { useAuth } from '@/utils/context/authContext';
 import { getSingleUser } from '@/api/profileData';
+import ProtectedRoute from '@/components/ProtectedRoute';
+import { Modal, Button } from 'react-bootstrap';
+import { useRouter } from 'next/navigation';
 
-export default function Profilepage() {
+export default function ProfilePage() {
   const { user } = useAuth();
-  const [userData, setUserData] = useState({});
+  const [userData, setUserData] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+  const router = useRouter();
 
   const getTheSingleUser = () => {
     getSingleUser(user.uid).then((data) => {
       console.log('Fetched User Data:', data);
-      setUserData(data[0]);
+      if (data[0] && data[0].first_name && data[0].last_name && data[0].bio) {
+        setUserData(data[0]);
+      } else {
+        setShowModal(true);
+      }
     });
   };
 
@@ -24,23 +32,44 @@ export default function Profilepage() {
     getTheSingleUser();
   }, []);
 
+  const handleRedirect = () => {
+    setShowModal(false);
+    router.push('/profile/new');
+  };
+
   return (
-    <>
-      <div style={{ maxWidth: '600px', margin: 'auto', padding: '30px', borderRadius: '15px', boxShadow: '0 6px 12px rgba(0, 0, 0, 0.1)', backgroundColor: '#f9fafb', textAlign: 'center' }}>
-        <div>
-          <img src={user.photoURL} alt="Profile" style={{ width: '120px', height: '120px', borderRadius: '50%', border: '4px solid #007bff', padding: '5px', backgroundColor: '#fff', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' }} />
-          <h2 style={{ marginTop: '15px', color: '#333', fontSize: '24px', fontWeight: '600' }}>
-            {userData.first_name} {userData.last_name}
-          </h2>
-          <p style={{ fontSize: '16px', color: '#777', fontStyle: 'italic', marginTop: '8px' }}>{userData.bio}</p>
-          <p style={{ fontWeight: '600', color: '#007bff', fontSize: '16px', marginTop: '10px' }}>Email: {user.email}</p>
-        </div>
-      </div>
+    <ProtectedRoute>
+      {showModal ? (
+        <Modal show={showModal} onHide={handleRedirect} centered>
+          <Modal.Header closeButton style={{ backgroundColor: '#f8f9fa', color: '#000' }}>
+            <Modal.Title>Profile Incomplete</Modal.Title>
+          </Modal.Header>
+          <Modal.Body style={{ backgroundColor: '#f8f9fa', color: '#000' }}>Please fill out the profile form first.</Modal.Body>
+          <Modal.Footer style={{ backgroundColor: '#f8f9fa', color: '#000' }}>
+            <Button variant="primary" onClick={handleRedirect}>
+              Go to Profile Form
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      ) : (
+        userData && (
+          <div style={{ maxWidth: '600px', margin: 'auto', padding: '30px', borderRadius: '15px', boxShadow: '0 6px 12px rgba(0, 0, 0, 0.1)', backgroundColor: '#f9fafb', textAlign: 'center' }}>
+            <div>
+              <img src={user.photoURL} alt="Profile" style={{ width: '120px', height: '120px', borderRadius: '50%', border: '4px solid #007bff', padding: '5px', backgroundColor: '#fff', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' }} />
+              <h2 style={{ marginTop: '15px', color: '#333', fontSize: '24px', fontWeight: '600' }}>
+                {userData.first_name} {userData.last_name}
+              </h2>
+              <p style={{ fontSize: '16px', color: '#777', fontStyle: 'italic', marginTop: '8px' }}>{userData.bio}</p>
+              <p style={{ fontWeight: '600', color: '#007bff', fontSize: '16px', marginTop: '10px' }}>Email: {user.email}</p>
+            </div>
+          </div>
+        )
+      )}
 
       <div style={{ padding: '20px', marginTop: '30px', maxWidth: '600px', margin: 'auto', textAlign: 'center' }}>
         <h3 style={{ color: '#fff', borderBottom: '2px solid #007bff', display: 'inline-block', paddingBottom: '8px', fontSize: '20px', fontWeight: '600' }}>Completed Tours</h3>
         <p style={{ color: '#ddd', fontSize: '16px', fontStyle: 'italic', marginTop: '5px' }}>(Coming soon)</p>
       </div>
-    </>
+    </ProtectedRoute>
   );
 }

--- a/src/app/tours/page.js
+++ b/src/app/tours/page.js
@@ -11,6 +11,7 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { getTours } from '@/api/tourData';
 import { useAuth } from '@/utils/context/authContext';
 import { getSingleLocation } from '@/api/locationData';
+import ProtectedRoute from '@/components/ProtectedRoute';
 
 export default function ToursPage() {
   const [tours, setTours] = useState([]);
@@ -30,7 +31,7 @@ export default function ToursPage() {
   }, []);
 
   return (
-    <>
+    <ProtectedRoute>
       <div className="text-center mt-3">
         <Link href="/tour/new" passHref>
           <Button className="w-25">
@@ -43,6 +44,6 @@ export default function ToursPage() {
           <TourCard key={tour.id} tourObj={tour} onUpdate={getAllTheTours} />
         ))}
       </div>
-    </>
+    </ProtectedRoute>
   );
 }

--- a/src/components/ProtectedRoute.js
+++ b/src/components/ProtectedRoute.js
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import UserProfileCheck from '@/utils/hooks/userProfileCheck';
+import { useRouter } from 'next/navigation';
+import { Modal, Button } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+export default function ProtectedRoute({ children }) {
+  const isProfileComplete = UserProfileCheck();
+  const router = useRouter();
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    // If user profile is not complete, show the modal
+    if (!isProfileComplete) {
+      setShowModal(true);
+    }
+  }, [isProfileComplete]);
+
+  const handleRedirect = () => {
+    setShowModal(false); // Close the modal
+    router.push('/profile/new'); // Redirect to the profile form on Create Profile Page
+  };
+
+  if (!isProfileComplete) {
+    return (
+      //  show and onHide are props that will be passed to the modal component. show prop: controlss whether modal is visible or not. onHide prop: defines what happens with the modal is dismissed.
+      // showModal will be set to true if the user profile is not complete. the modal will be displayed if the user profile is not complete. the user will be redirected to the profile form page if they click the button in the modal.
+      <Modal show={showModal} onHide={handleRedirect} style={{ backgroundColor: '#f8f9fa', color: '#000' }}>
+        <Modal.Header closeButton>
+          <Modal.Title>Profile Incomplete</Modal.Title>
+        </Modal.Header>
+        <Modal.Body style={{ backgroundColor: '#f8f9fa', color: '#000' }}>Please fill out the profile form first.</Modal.Body>
+        <Modal.Footer style={{ backgroundColor: '#f8f9fa', color: '#000' }}>
+          <Button variant="primary" onClick={handleRedirect}>
+            Go to Profile Form
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+  return <> {children} </>;
+}
+
+ProtectedRoute.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/utils/hooks/userProfileCheck.js
+++ b/src/utils/hooks/userProfileCheck.js
@@ -1,0 +1,22 @@
+import { useAuth } from '@/utils/context/authContext';
+import { useState, useEffect } from 'react';
+import { getSingleUser } from '@/api/profileData';
+
+export default function UserProfileCheck() {
+  const { user } = useAuth();
+  const [isProfileComplete, setIsProfileComplete] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      getSingleUser(user.uid).then((data) => {
+        if (data && data[0] && data[0].first_name && data[0].last_name && data[0].bio) {
+          setIsProfileComplete(true); // If user data is available, set isProfileComplete to true
+        } else {
+          setIsProfileComplete(false); // If user data is not available, set isProfileComplete to false
+        }
+      });
+    }
+  }, [user]); // Run this effect when user changes
+
+  return isProfileComplete;
+}


### PR DESCRIPTION
## Description
- Created a custom hook to check user profile completion (UserProfileCheck.js in utiils/hooks)
- Implemented a higher-order component (HOC) for protected routes. will wrap pages that should not be accessed until user form is completed in this ProtectedRoute. when profile is not completed, it shows a modal, which redirects them to profile form when dismissed.
- Wrapped protected components with the HOC or the ProtectedRoute
    - all pages except home. for now just doing the pages accessible via navbar. technically they still could change the url to the other pages and get to them but that is highly unlikely. wrapped the following pages: itinerary, locations, profile, tours
    - also had to do modal directly in profile page because it was throwing an error instead of showing the modal there. this is happening bc the profile page component is trying to access user data before the protected route can handle the incomplete profile check. i couldn’t figure out how to counteract that and this was the easier fix
- home page redirects to either tours or profile form accordingly
- there is a bug for a profile that already has filled out the form. when clicking a page in the nav bar, seems like it’s flashing the modal really quickly (it shouldn’t show at all) before displaying the correct page contents. I can check this out more later

To test the modal, need to use an account that hasn’t yet filled out the profile form. Could also prob just delete your user obj in postman?

lmk if any merge conflicts arise!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
